### PR TITLE
Improve detecting server executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+
+server/*

--- a/package.json
+++ b/package.json
@@ -24,6 +24,26 @@
           }
         ]
       }
+    ],
+    "configuration": [
+      {
+        "title": "Snail",
+        "properties": {
+          "snail.server.executable": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null,
+            "description": "Path to the snail server executable. If unset, the executable packaged with the extension will be used."
+          },
+          "snail.server.debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to start the server in debug mode. In this mode the server will wait for a debugger to attach right after start and will not do anything until then."
+          }
+        }
+      }
     ]
   },
   "main": "./out/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	initDecorations();
 
-	client = new Client();
+	client = new Client(context.extensionPath);
 	client.start();
 }
 


### PR DESCRIPTION
By default the server executable is now taken from `<extension-root>/server/bin/snail-server[.exe]`, but an alternative executable path can be configured via the extension settings.

An additional setting has been introduced to control whether to pass the `--debug` flag when starting the server.