### PR TITLE
Fix packaging codicons

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,6 +19,8 @@ webview-ui/index.html
 webview-ui/package.json
 webview-ui/package-lock.json
 webview-ui/node_modules/**
+!webview-ui/node_modules/@vscode/codicons/dist/codicon.css
+!webview-ui/node_modules/@vscode/codicons/dist/codicon.ttf
 
 # Ignore Misc
 .yarnrc

--- a/src/editor/sessioneditor.ts
+++ b/src/editor/sessioneditor.ts
@@ -78,11 +78,9 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
         const stylesUri = getUri(webview, this.extensionUri, ["webview-ui", "build", "assets", "index.css"]);
         const scriptUri = getUri(webview, this.extensionUri, ["webview-ui", "build", "assets", "index.js"]);
 
-        const codiconsUri = getUri(webview, this.extensionUri, ["webview-ui", "node_modules", "@vscode/codicons", "dist", "codicon.css"]);
+        const codiconsUri = getUri(webview, this.extensionUri, ["webview-ui", "node_modules", "@vscode", "codicons", "dist", "codicon.css"]);
 
         const nonce = getNonce();
-
-        // <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
 
         return /* html */`
             <!DOCTYPE html>
@@ -95,6 +93,9 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                     <title>Performance Session</title>
                     <meta charset="UTF-8" />
                     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+                    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+
                     <link rel="stylesheet" type="text/css" href="${stylesUri}"/>
                     <link rel="stylesheet" type="text/css" href="${codiconsUri}"/>
                 </head>


### PR DESCRIPTION
We embed the codicon files directly from the `node_modules` directory, and hence we need to make sure those files are packaged correctly.

Although I am not sure whether it is a good idea to embed the files directly from the `node_modules` directory, this is how it is done in the [official VS Code sample](https://github.com/microsoft/vscode-extension-samples/blob/f1df8faee789ed72a42010a42e10bc9baf624929/webview-codicons-sample/src/extension.ts#L34).