### PR TITLE
Register *.diagsession files for this extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
             "filenamePattern": "*.etl"
           },
           {
+            "filenamePattern": "*.diagsession"
+          },
+          {
             "filenamePattern": "*perf.data"
           }
         ]


### PR DESCRIPTION
Support for `*.diagsession` files has been implemented in the backend in https://github.com/albertziegenhagel/snail-server/pull/7.