### PR TITLE
Improve timeline with filtering support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -305,6 +305,23 @@ export class Client {
 		return result.then((data) => { return data.processes; });
 	}
 
+	public async setSampleFilter(documentId: number, minTime: number|null, maxTime: number|null, excludedProcesses: number[], excludedThreads: number[]): Promise<null> {
+		await this._started;
+		if (this._connection === undefined) {
+			return Promise.reject<null>("Client is not connected");
+		}
+
+		const result = this._connection.sendRequest(protocol.setSampleFiltersRequestType, {
+			documentId: documentId,
+			minTime: minTime,
+			maxTime: maxTime,
+			excludedProcesses: excludedProcesses,
+			excludedThreads: excludedThreads,
+		});
+
+		return result;
+	}
+
 	public async retrieveHottestFunctions(documentId: number, count: number = 4): Promise<protocol.ProcessFunction[]> {
 		await this._started;
 		if (this._connection === undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -320,7 +320,7 @@ export class Client {
 		return result.then((data) => { return data.functions; });
 	}
 
-	public async retrieveCallTreeHotPath(documentId: number, processId: number): Promise<protocol.CallTreeNode> {
+	public async retrieveCallTreeHotPath(documentId: number, processKey: number): Promise<protocol.CallTreeNode> {
 		await this._started;
 		if (this._connection === undefined) {
 			return Promise.reject<protocol.CallTreeNode>("Client is not connected");
@@ -328,14 +328,14 @@ export class Client {
 
 		const result = this._connection.sendRequest(protocol.retrieveCallTreeHotPathRequestType, {
 			documentId: documentId,
-			processId: processId
+			processKey: processKey
 		});
 
 		return result.then((data) => { return data.root; });
 	}
 
 
-	public async retrieveFunctionsPage(documentId: number, processId: number,
+	public async retrieveFunctionsPage(documentId: number, processKey: number,
 		pageSize: number, pageIndex: number): Promise<protocol.FunctionNode[]> {
 		await this._started;
 		if (this._connection === undefined) {
@@ -344,7 +344,7 @@ export class Client {
 
 		const result = this._connection.sendRequest(protocol.retrieveFunctionsPageRequestType, {
 			documentId: documentId,
-			processId: processId,
+			processKey: processKey,
 			pageSize: pageSize,
 			pageIndex: pageIndex
 		});
@@ -352,7 +352,7 @@ export class Client {
 		return result.then((data) => { return data.functions; });
 	}
 
-	public async expandCallTreeNode(documentId: number, processId: number, nodeId: number): Promise<protocol.CallTreeNode[]> {
+	public async expandCallTreeNode(documentId: number, processKey: number, nodeId: number): Promise<protocol.CallTreeNode[]> {
 		await this._started;
 		if (this._connection === undefined) {
 			return Promise.reject<protocol.CallTreeNode[]>("Client is not connected");
@@ -360,7 +360,7 @@ export class Client {
 
 		const result = this._connection.sendRequest(protocol.expandCallTreeNodeRequestType, {
 			documentId: documentId,
-			processId: processId,
+			processKey: processKey,
 			nodeId: nodeId
 		});
 
@@ -368,7 +368,7 @@ export class Client {
 	}
 
 
-	public async retrieveCallersCallees(documentId: number, processId: number, functionId: number, maxEntries: number = 6): Promise<protocol.RetrieveCallersCalleesResult> {
+	public async retrieveCallersCallees(documentId: number, processKey: number, functionId: number, maxEntries: number = 6): Promise<protocol.RetrieveCallersCalleesResult> {
 		await this._started;
 		if (this._connection === undefined) {
 			return Promise.reject<protocol.RetrieveCallersCalleesResult>("Client is not connected");
@@ -376,7 +376,7 @@ export class Client {
 
 		const result = this._connection.sendRequest(protocol.retrieveCallersCalleesRequestType, {
 			documentId: documentId,
-			processId: processId,
+			processKey: processKey,
 			functionId: functionId,
 			maxEntries: maxEntries
 		});
@@ -407,7 +407,7 @@ export class Client {
 	}
 
 
-	public async retrieveLineInfo(documentId: number, processId: number, functionId: number): Promise<protocol.RetrieveLineInfoResult|null> {
+	public async retrieveLineInfo(documentId: number, processKey: number, functionId: number): Promise<protocol.RetrieveLineInfoResult|null> {
 		await this._started;
 		if (this._connection === undefined) {
 			return Promise.reject<protocol.RetrieveLineInfoResult|null>("Client is not connected");
@@ -415,7 +415,7 @@ export class Client {
 
 		const result = this._connection.sendRequest(protocol.retrieveLineInfoRequestType, {
 			documentId: documentId,
-			processId: processId,
+			processKey: processKey,
 			functionId: functionId,
 		});
 

--- a/src/editor/sessioneditor.ts
+++ b/src/editor/sessioneditor.ts
@@ -121,6 +121,21 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                                 vscode.window.showErrorMessage(`Failed to retrieve processes: ${reason}`);
                             });
                         return;
+                    case "setSampleFilter":
+                        client.setSampleFilter(document.documentId, message.minTime, message.maxTime, message.excludedProcesses, message.excludedThreads).then(
+                            () => {
+                                webview.postMessage({
+                                    "type": "filterSet",
+                                    "data": {
+                                        minTime: message.minTime,
+                                        maxTime: message.maxTime
+                                    }
+                                });
+                            },
+                            (reason) => {
+                                vscode.window.showErrorMessage(`Failed to set sample filter: ${reason}`);
+                            });
+                        return;
                     case "retrieveHottestFunctions":
                         client.retrieveHottestFunctions(document.documentId).then(
                             (functions) => {

--- a/src/editor/sessioneditor.ts
+++ b/src/editor/sessioneditor.ts
@@ -136,12 +136,12 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                             });
                         return;
                     case "retrieveCallTreeHotPath":
-                        client.retrieveCallTreeHotPath(document.documentId, message.processId).then(
+                        client.retrieveCallTreeHotPath(document.documentId, message.processKey).then(
                             (root) => {
                                 webview.postMessage({
                                     "type": "callTreeHotPath",
                                     "data": {
-                                        "processId": message.processId,
+                                        "processKey": message.processKey,
                                         "root": root
                                     }
                                 });
@@ -151,7 +151,7 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                             });
                         return;
                     case "retrieveFunctionsPage":
-                        client.retrieveFunctionsPage(document.documentId, message.processId, message.pageSize, message.pageIndex).then(
+                        client.retrieveFunctionsPage(document.documentId, message.processKey, message.pageSize, message.pageIndex).then(
                             (functions) => {
                                 webview.postMessage({
                                     "type": "functionsPage",
@@ -167,7 +167,7 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                             });
                         return;
                     case "expandCallTreeNode":
-                        client.expandCallTreeNode(document.documentId, message.processId, message.nodeId).then(
+                        client.expandCallTreeNode(document.documentId, message.processKey, message.nodeId).then(
                             (children) => {
                                 webview.postMessage({
                                     "type": "callTreeNodeChildren",
@@ -182,12 +182,12 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                             });
                         return;
                     case "retrieveCallersCallees":
-                        client.retrieveCallersCallees(document.documentId, message.processId, message.functionId).then(
+                        client.retrieveCallersCallees(document.documentId, message.processKey, message.functionId).then(
                             (result) => {
                                 webview.postMessage({
                                     "type": "callersCallees",
                                     "data": {
-                                        "processId": message.processId,
+                                        "processKey": message.processKey,
                                         "function": result.function,
                                         "callers": result.callers,
                                         "callees": result.callees
@@ -224,7 +224,7 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                         );
                         return;
                     case "navigateToFunction":
-                        client.retrieveLineInfo(document.documentId, message.processId, message.functionId).then(
+                        client.retrieveLineInfo(document.documentId, message.processKey, message.functionId).then(
                             (result) => {
                                 if (result === undefined) {
                                     return;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -312,6 +312,22 @@ export interface SetModuleFiltersParams {
     include: string[];
 }
 
+export interface SetSampleFiltersParams {
+    excludedProcesses: number[];
+
+    excludedThreads: number[];
+
+    // The id of the document to perform the operation on.
+    // This should be an id that resulted from a call to `readDocument`.
+    documentId: number;
+
+    // In nanoseconds since session start.
+    minTime: number | null;
+
+    // In nanoseconds since session start.
+    maxTime: number | null;
+}
+
 
 export const initializeRequestType = new rpc.RequestType<InitializeParams, InitializeResult, void>('initialize');
 
@@ -347,6 +363,9 @@ export const retrieveCallersCalleesRequestType = new rpc.RequestType<RetrieveCal
 
 
 export const retrieveLineInfoRequestType = new rpc.RequestType<RetrieveLineInfoParams, RetrieveLineInfoResult | null, void>('retrieveLineInfo');
+
+
+export const setSampleFiltersRequestType = new rpc.RequestType<SetSampleFiltersParams, null, void>('setSampleFilters');
 
 
 export const closeDocumentNotificationType = new rpc.NotificationType<CloseDocumentParams>('closeDocument');

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -9,7 +9,9 @@ export enum ModuleFilterMode {
 }
 
 export interface ThreadInfo {
-    id: number;
+    key: number;
+
+    osId: number;
 
     // Time when the thread started (in nanoseconds since the session start).
     startTime: number;
@@ -21,7 +23,9 @@ export interface ThreadInfo {
 }
 
 export interface ProcessInfo {
-    id: number;
+    key: number;
+
+    osId: number;
 
     name: string;
 
@@ -106,7 +110,7 @@ export interface FunctionNode {
 }
 
 export interface ProcessFunction {
-    processId: number;
+    processKey: number;
 
     function: FunctionNode;
 }
@@ -181,7 +185,7 @@ export interface RetrieveHottestFunctionsResult {
 }
 
 export interface RetrieveCallTreeHotPathParams {
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -197,7 +201,7 @@ export interface RetrieveFunctionsPageParams {
 
     pageIndex: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -211,7 +215,7 @@ export interface RetrieveFunctionsPageResult {
 export interface ExpandCallTreeNodeParams {
     nodeId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -227,7 +231,7 @@ export interface RetrieveCallersCalleesParams {
 
     functionId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -245,7 +249,7 @@ export interface RetrieveCallersCalleesResult {
 export interface RetrieveLineInfoParams {
     functionId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.

--- a/webview-ui/src/App.svelte
+++ b/webview-ui/src/App.svelte
@@ -54,13 +54,13 @@
     activeFunction = functionId;
     vscode.postMessage({
       command: "retrieveCallersCallees",
-      processId: activeFunction.processId,
+      processKey: activeFunction.processKey,
       functionId: activeFunction.functionId,
     });
     if(navigate) {
       vscode.postMessage({
         command: "navigateToFunction",
-        processId: activeFunction.processId,
+        processKey: activeFunction.processKey,
         functionId: activeFunction.functionId,
       });
     }
@@ -103,28 +103,28 @@
     if (event.data.type === "processes") {
       processes = event.data.data;
       for (const process of processes) {
-        if (callTreeRoots === null || !(process.id in callTreeRoots)) {
+        if (callTreeRoots === null || !(process.key in callTreeRoots)) {
           vscode.postMessage({
             command: "retrieveCallTreeHotPath",
-            processId: process.id,
+            processKey: process.key,
           });
           if (callTreeRoots === null) {
             callTreeRoots = new Map<number, CallTreeNode>();
           }
-          callTreeRoots.set(process.id, null);
+          callTreeRoots.set(process.key, null);
         }
       }
       if (callTreeRoots !== null) {
-        for (let processId of callTreeRoots.keys()) {
+        for (let processKey of callTreeRoots.keys()) {
           let hasProcess = false;
           for (const process of processes) {
-            if (process.id === processId) {
+            if (process.key === processKey) {
               hasProcess = true;
               break;
             }
           }
           if (!hasProcess) {
-            callTreeRoots.delete(processId);
+            callTreeRoots.delete(processKey);
           }
         }
       }
@@ -132,11 +132,11 @@
     }
 
     if (event.data.type === "callersCallees") {
-      if (event.data.data["processId"] !== activeFunction?.processId) return;
+      if (event.data.data["processKey"] !== activeFunction?.processKey) return;
       if (event.data.data["function"]["id"] !== activeFunction?.functionId)
         return;
       activeCallerCalleeNode = {
-        processId: activeFunction.processId,
+        processKey: activeFunction.processKey,
         function: event.data.data["function"],
         callers: event.data.data["callers"],
         callees: event.data.data["callees"],
@@ -144,7 +144,7 @@
     }
 
     if (event.data.type === "callTreeHotPath") {
-      callTreeRoots.set(event.data.data["processId"], event.data.data["root"]);
+      callTreeRoots.set(event.data.data["processKey"], event.data.data["root"]);
       callTreeRoots = callTreeRoots;
     }
 
@@ -152,7 +152,7 @@
       hotFunctions = event.data.data["functions"];
       if (activeFunction == null && hotFunctions.length > 0) {
         changeActiveFunction({
-          processId: hotFunctions[0].processId,
+          processKey: hotFunctions[0].processKey,
           functionId: hotFunctions[0].function.id,
         }, false);
       }

--- a/webview-ui/src/CallTree.svelte
+++ b/webview-ui/src/CallTree.svelte
@@ -13,8 +13,8 @@
   // $: {
   //   if(processes !== null) {
   //     for (const process of processes) {
-  //       if(process.id in roots) continue;
-  //       vscode.postMessage({ command: "retrieveCallTreeHotPath", processId: process.id });
+  //       if(process.key in roots) continue;
+  //       vscode.postMessage({ command: "retrieveCallTreeHotPath", processKey: process.key });
   //     }
   //     // TODO: remove old roots
   //   }
@@ -25,19 +25,19 @@
 
   // window.addEventListener("message", (event) => {
   //   if(event.data.type !== "callTreeHotPath") return;
-  //   roots[event.data.data['processId']] = event.data.data['root'];
+  //   roots[event.data.data['processKey']] = event.data.data['root'];
   // });
 </script>
 
 <FunctionTable stickyHeader={true}>
   {#if roots !== null}
-    {#each [...roots] as [processId, root]}
+    {#each [...roots] as [processKey, root]}
       <TreeFunctionTableRow
         on:navigate={(event) =>
           dispatch("navigate", {
             functionId: event.detail.functionId,
           })}
-        {processId}
+        {processKey}
         node={root}
         level={0}
         {activeFunction}

--- a/webview-ui/src/CallerCallee.svelte
+++ b/webview-ui/src/CallerCallee.svelte
@@ -12,10 +12,10 @@
   // let callers: Function[] = [];
   // let callees: Function[] = [];
 
-  // $: if (activeFunction !== null && activeFunction.processId !== null && activeFunction.functionId !== null) {
+  // $: if (activeFunction !== null && activeFunction.processKey !== null && activeFunction.functionId !== null) {
   //   vscode.postMessage({
   //     command: "retrieveCallersCallees",
-  //     processId: activeFunction.processId,
+  //     processKey: activeFunction.processKey,
   //     functionId: activeFunction.functionId,
   //   });
   // }
@@ -23,7 +23,7 @@
   function navigateTo(func: FunctionNode) {
     dispatch("navigate", {
       functionId: {
-        processId: node.processId,
+        processKey: node.processKey,
         functionId: func.id,
       },
     });

--- a/webview-ui/src/Summary.svelte
+++ b/webview-ui/src/Summary.svelte
@@ -35,14 +35,14 @@
                         on:navigate={() =>
                             dispatch("navigate", {
                                 functionId: {
-                                    processId: func.processId,
+                                    processKey: func.processKey,
                                     functionId: func.function.id,
                                 },
                             })}
                         func={func.function}
                         isHot={true}
-                        isActive={func.processId ==
-                            activeFunction?.processId &&
+                        isActive={func.processKey ==
+                            activeFunction?.processKey &&
                             func.function.id == activeFunction?.functionId}
                     />
                 {/each}

--- a/webview-ui/src/Summary.svelte
+++ b/webview-ui/src/Summary.svelte
@@ -20,12 +20,134 @@
     export let hotFunctions: ProcessFunction[] = null;
     export let activeFunction: FunctionId;
 
+    export let activeSelectionFilter: TimeSpan|null = null;
+
+    let activeSelection: TimeSpan;
+
+    let wipSelectionFilter: TimeSpan = null;
+
+    let excludedProcesses: number[] = []
+    let excludedThreads: number[] = []
+
+    let activeExcludedProcesses: number[] = []
+    let activeExcludedThreads: number[] = []
+
     const dispatch = createEventDispatcher();
+
+    $: hasSelection = activeSelection !== null;
+
+    $: hasSelectionFilter = activeSelectionFilter !== null && (activeSelectionFilter.start !== null || activeSelectionFilter.end !== null);
+
+    $: displayTime = totalTime;
+
+    $: isZoomed = totalTime !== null && displayTime !== null &&
+        (displayTime.start > totalTime.start || displayTime.end < totalTime.end);
+
+    function arrayEquals(a:number[], b:number[]) {
+      return a.length === b.length && a.every((val, index) => val === b[index]);
+    }
+
+    $: hasFilterChanges = hasSelection ||
+      !arrayEquals(excludedProcesses, activeExcludedProcesses) ||
+      !arrayEquals(excludedThreads, activeExcludedThreads);
+
+    function clearSelection() {
+      activeSelection = null;
+    }
+
+    function applyFiler() {
+      if(activeSelection !== null) {
+        wipSelectionFilter = {
+          start: activeSelection.start,
+          end: activeSelection.end
+        };
+      }
+      else if(activeSelectionFilter !== null){
+        wipSelectionFilter = {
+          start: activeSelectionFilter.start,
+          end: activeSelectionFilter.end
+        };
+      }
+      else {
+        wipSelectionFilter = {
+          start: null,
+          end: null
+        };
+      }
+      console.log(wipSelectionFilter);
+      dispatch("filter", {
+        minTime: wipSelectionFilter.start,
+        maxTime: wipSelectionFilter.end,
+        excludedProcesses: excludedProcesses,
+        excludedThreads: excludedThreads
+      });
+      activeExcludedProcesses = [...excludedProcesses];
+      activeExcludedThreads = [...excludedThreads];
+      zoomToSelection();
+    }
+
+    function clearSelectionFilter() {
+      wipSelectionFilter = {
+        start: null,
+        end: null
+      };
+      dispatch("filter", {
+        minTime: wipSelectionFilter.start,
+        maxTime: wipSelectionFilter.end,
+        excludedProcesses: excludedProcesses,
+        excludedThreads: excludedThreads
+      });
+      resetZoom();
+    }
+
+    function zoomToSelection() {
+      if(activeSelection === null) {
+        return;
+      }
+      displayTime = activeSelection;
+      activeSelection = null;
+    }
+    function resetZoom() {
+      displayTime = totalTime;
+    }
+
 </script>
 
 <div class="container">
     <Pane title="Timeline">
-        <TimeLine {processes} {totalTime} />
+        <TimeLine
+          bind:selection={activeSelection}
+          {displayTime}
+          {processes}
+          {activeFunction}
+          {activeSelectionFilter}
+          bind:uncheckedProcesses={excludedProcesses}
+          bind:uncheckedThreads={excludedThreads}
+        />
+
+        <div class="toolbar-buttons" slot="toolbar">
+          <vscode-button appearance="icon" aria-label="Apply Filter" title="Apply Filter" disabled={!hasFilterChanges} on:click={applyFiler} on:keypress={applyFiler}>
+            <span class="codicon codicon-filter"></span>
+          </vscode-button>
+          <vscode-button appearance="icon" aria-label="Reset Selection Filter" title="Reset Selection Filter" disabled={!hasSelectionFilter} on:click={clearSelectionFilter} on:keypress={clearSelectionFilter}>
+            <!-- <span class="codicon codicon-refresh"></span> -->
+            <span class="icon-group">
+              <span class="codicon codicon-filter"></span>
+              <span class="icon-corner codicon codicon-error"></span>
+            </span>
+          </vscode-button>
+
+          <vscode-button appearance="icon" aria-label="Clear Selection" title="Clear Selection" disabled={!hasSelection} on:click={clearSelection} on:keypress={clearSelection}>
+            <span class="codicon codicon-clear-all"></span>
+          </vscode-button>
+
+          <vscode-button appearance="icon" aria-label="Zoom to Selection" title="Zoom to Selection" disabled={!hasSelection} on:click={zoomToSelection} on:keypress={zoomToSelection}>
+            <span class="codicon codicon-zoom-in"></span>
+          </vscode-button>
+          <vscode-button appearance="icon" aria-label="Reset Zoom" title="Reset Zoom" disabled={!isZoomed} on:click={resetZoom} on:keypress={resetZoom}>
+            <span class="codicon codicon-zoom-out"></span>
+          </vscode-button>
+        </div>
     </Pane>
     <Pane title="Hot spots">
         <FunctionTable>
@@ -64,4 +186,22 @@
 </div>
 
 <style>
+  .toolbar-buttons {
+    display: flex;
+    gap: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+  }
+
+  .icon-group {
+    position: relative;
+  }
+
+  span.icon-corner {
+    position: absolute;
+    bottom: 0;
+    right: -2px;
+    font-size: 8px;
+    font-weight: bold;
+  }
 </style>

--- a/webview-ui/src/components/Pane.svelte
+++ b/webview-ui/src/components/Pane.svelte
@@ -9,9 +9,13 @@
 </script>
 
 <div class="pane">
-    <div on:click={toggleExpansion} on:keypress={toggleExpansion} class="pane-header">
-        <div class="twistie codicon codicon-chevron-down" class:collapsed={!expanded}></div>
-        <h3 class="title" title="{title}">{title}</h3>
+    <div on:click|self={toggleExpansion} on:keypress|self={toggleExpansion} class="pane-header">
+        <div on:click|self={toggleExpansion} on:keypress|self={toggleExpansion} class="twistie codicon codicon-chevron-down" class:collapsed={!expanded}></div>
+        <h3 on:click|self={toggleExpansion} on:keypress|self={toggleExpansion} class="title" title="{title}">{title}</h3>
+
+        <div class="toolbar">
+          <slot name="toolbar"></slot>
+        </div>
     </div>
     <div class="pane-body" class:collapsed={!expanded}>
         <slot></slot>
@@ -20,7 +24,9 @@
 
 <style>
     .pane-header {
+        height: 22px;
         line-height: 22px;
+        box-sizing: border-box;
         color: var(--vscode-sideBarSectionHeader-foreground);
         background-color: var(--vscode-sideBarSectionHeader-background);
         border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
@@ -35,6 +41,9 @@
         margin-block-start: 0;
         margin-block-end: 0;
         font-size: 11px;
+    }
+    .pane-header .toolbar {
+        margin-left: auto;
     }
 
     .pane-body {

--- a/webview-ui/src/components/TimeLine.svelte
+++ b/webview-ui/src/components/TimeLine.svelte
@@ -55,7 +55,7 @@
                   class:codicon-check={checked[processIndex].process}
                   bind:checked={checked[processIndex].process}
                 />
-                {process.name} (PID: {process.id})
+                {process.name} (PID: {process.osId})
               </div>
             </div>
           </td>
@@ -104,7 +104,7 @@
                       bind:checked={checked[processIndex].threads[threadIndex]}
                       disabled={!checked[processIndex].process}
                     />
-                    {thread.name === null ? "[thread]" : thread.name} (TID: {thread.id})
+                    {thread.name === null ? "[thread]" : thread.name} (TID: {thread.osId})
                   </div>
                 </div>
               </td>

--- a/webview-ui/src/components/TreeFunctionTableRow.svelte
+++ b/webview-ui/src/components/TreeFunctionTableRow.svelte
@@ -6,7 +6,7 @@
 
     import FunctionTableRow from "./FunctionTableRow.svelte";
 
-    export let processId: number;
+    export let processKey: number;
     export let node: CallTreeNode;
     export let level: number;
     export let activeFunction: FunctionId;
@@ -28,7 +28,7 @@
     }
 
     $: isHot = node !== null && node.isHot;
-    $: isActive = node !== null && activeFunction != null && processId == activeFunction.processId && node.functionId == activeFunction.functionId;
+    $: isActive = node !== null && activeFunction != null && processKey == activeFunction.processKey && node.functionId == activeFunction.functionId;
 
     const toggleExpansion = () => {
         if(expanded === null) {
@@ -40,7 +40,7 @@
         if (expanded && node.children === null) {
             vscode.postMessage({
                 command: "expandCallTreeNode",
-                processId: processId,
+                processKey: processKey,
                 nodeId: node.id,
             });
         }
@@ -49,7 +49,7 @@
     function navigateToSelf() {
         dispatch("navigate", {
             functionId: {
-                processId: processId,
+                processKey: processKey,
                 functionId: node.functionId,
             },
         });
@@ -96,7 +96,7 @@
             <svelte:self
                 on:navigate={(event) =>
                     navigateToChild(event.detail.functionId)}
-                {processId}
+                {processKey}
                 node={child}
                 level={level + 1}
                 {activeFunction}
@@ -105,7 +105,7 @@
     {:else}
         <!-- Placeholder -->
         <svelte:self
-            {processId}
+            {processKey}
             node={null}
             level={level + 1}
         />

--- a/webview-ui/src/utilities/types.ts
+++ b/webview-ui/src/utilities/types.ts
@@ -7,14 +7,16 @@ export interface TimeSpan {
 }
 
 export interface ThreadInfo {
-    id: number;
+    key: number;
+    osId: number;
     name: string;
     startTime: number;
     endTime: number;
 }
 
 export interface ProcessInfo {
-    id: number;
+    key: number;
+    osId: number;
     name: string;
     startTime: number;
     endTime: number;
@@ -47,18 +49,18 @@ export interface CallTreeNode {
 };
 
 export interface CallerCalleeNode {
-    processId : number;
+    processKey : number;
     function : FunctionNode;
     callers : FunctionNode[];
     callees : FunctionNode[];
 };
 
 export interface FunctionId {
-    processId : number;
+    processKey : number;
     functionId : number;
 };
 
 export interface ProcessFunction {
-    processId : number;
+    processKey: number;
     function : FunctionNode;
 };


### PR DESCRIPTION
Improves the timeline to support filtering:

- A time range can be selected in the time line widget.
- Zooming is supported based on the selection.
- Applying time interval filters is supported based on the selection.
- Processes & threads that are unchecked can be filtered.

To support the process & thread filtering the server has introduced unique keys to identify processes and threads instead of the OS provided PID/TID. This is reflected by changes to the server communication protocol.