### PR TITLE
Remove dependency to `vscode/webview-ui-toolkit`

### DIFF
--- a/src/editor/sessioneditor.ts
+++ b/src/editor/sessioneditor.ts
@@ -97,7 +97,7 @@ export class PerformanceSessionEditorProvider implements vscode.CustomReadonlyEd
                     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
 
                     <link rel="stylesheet" type="text/css" href="${stylesUri}"/>
-                    <link rel="stylesheet" type="text/css" href="${codiconsUri}"/>
+                    <link rel="stylesheet" type="text/css" href="${codiconsUri}" id="vscode-codicon-stylesheet"/>
                 </head>
                 <body>
                     <script type="module" nonce="${nonce}" src="${scriptUri}"></script>

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@types/node": "^18.19.31",
         "@types/vscode-webview": "^1.57.5",
+        "@vscode-elements/elements": "^1.11.0",
         "@vscode/codicons": "^0.0.35",
         "@vscode/webview-ui-toolkit": "^1.4.0"
       },
@@ -479,6 +480,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "node_modules/@microsoft/fast-element": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.14.0.tgz",
@@ -854,11 +870,26 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/vscode-webview": {
       "version": "1.57.5",
       "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
       "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
       "license": "MIT"
+    },
+    "node_modules/@vscode-elements/elements": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.11.0.tgz",
+      "integrity": "sha512-vC1QDaelqERypHinavJbe4Bl4/g66CVJWKFWFXZyp1seBvTxkgscayDTiE//H95V8b75BgLPDAS1y3pbSIKXag==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
     },
     "node_modules/@vscode/codicons": {
       "version": "0.0.35",
@@ -1089,6 +1120,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/locate-character": {

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -9,8 +9,7 @@
         "@types/node": "^18.19.31",
         "@types/vscode-webview": "^1.57.5",
         "@vscode-elements/elements": "^1.11.0",
-        "@vscode/codicons": "^0.0.35",
-        "@vscode/webview-ui-toolkit": "^1.4.0"
+        "@vscode/codicons": "^0.0.35"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
@@ -495,52 +494,6 @@
         "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.14.0.tgz",
-      "integrity": "sha512-zXvuSOzvsu8zDTy9eby8ix8VqLop2rwKRgp++ZN2kTCsoB3+QJVoaGD2T/Cyso2ViZQFXNpiNCVKfnmxBvmWkQ==",
-      "license": "MIT"
-    },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.50.0.tgz",
-      "integrity": "sha512-8mFYG88Xea1jZf2TI9Lm/jzZ6RWR8x29r24mGuLojNYqIR2Bl8+hnswoV6laApKdCbGMPKnsAL/O68Q0sRxeVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.14.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.25.tgz",
-      "integrity": "sha512-jKzmk2xJV93RL/jEFXEZgBvXlKIY4N4kXy3qrjmBfFpqNi3VjY+oUTWyMnHRMC5EUhIFxD+Y1VD4u9uIPX3jQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.14.0",
-        "@microsoft/fast-foundation": "^2.50.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "license": "MIT",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz",
@@ -897,22 +850,6 @@
       "integrity": "sha512-7iiKdA5wHVYSbO7/Mm0hiHD3i4h+9hKUe1O4hISAe/nHhagMwb2ZbFC8jU6d7Cw+JNT2dWXN2j+WHbkhT5/l2w==",
       "license": "CC-BY-4.0"
     },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "deprecated": "This package has been deprecated, https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1065,12 +1002,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
-    },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==",
-      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.4.3",
@@ -1242,16 +1173,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
@@ -1378,16 +1299,11 @@
         "typescript": ">=5.0.0"
       }
     },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@types/node": "^18.19.31",
     "@types/vscode-webview": "^1.57.5",
+    "@vscode-elements/elements": "^1.11.0",
     "@vscode/codicons": "^0.0.35",
     "@vscode/webview-ui-toolkit": "^1.4.0"
   }

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -21,7 +21,6 @@
     "@types/node": "^18.19.31",
     "@types/vscode-webview": "^1.57.5",
     "@vscode-elements/elements": "^1.11.0",
-    "@vscode/codicons": "^0.0.35",
-    "@vscode/webview-ui-toolkit": "^1.4.0"
+    "@vscode/codicons": "^0.0.35"
   }
 }

--- a/webview-ui/src/App.svelte
+++ b/webview-ui/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { SvelteMap } from 'svelte/reactivity';
+  import "@vscode-elements/elements";
 
   import { vscode } from "./utilities/vscode";
   import type {
@@ -14,21 +15,10 @@
     InfoEntry,
   } from "./utilities/types";
 
-  import {
-    provideVSCodeDesignSystem,
-    vsCodeProgressRing,
-  } from "@vscode/webview-ui-toolkit";
-
-  import "@vscode-elements/elements";
-
   import Summary from "./Summary.svelte";
   import CallTree from "./CallTree.svelte";
   import CallerCallee from "./CallerCallee.svelte";
   import FunctionsPage from "./FunctionsPage.svelte";
-
-  provideVSCodeDesignSystem().register(
-    vsCodeProgressRing(),
-  );
 
   let totalTime: TimeSpan | null = $state(null);
   let sampleSources: SampleSourceInfo[] = $state([]);
@@ -362,6 +352,10 @@
 </main>
 
 <style>
+  :global(:root) {
+    --design-unit: 4;
+  }
+
   main {
     height: 100%;
   }
@@ -371,9 +365,6 @@
     display: flex;
     flex-direction: column;
   }
-  /* :global(vscode-tabs > .header.panel) {
-    background-color: var(--background);
-  } */
   vscode-tab-header {
     text-transform: uppercase;
   }

--- a/webview-ui/src/App.svelte
+++ b/webview-ui/src/App.svelte
@@ -16,12 +16,11 @@
 
   import {
     provideVSCodeDesignSystem,
-    vsCodePanels,
-    vsCodePanelView,
-    vsCodePanelTab,
     vsCodeProgressRing,
     vsCodeButton,
   } from "@vscode/webview-ui-toolkit";
+
+  import "@vscode-elements/elements";
 
   import Summary from "./Summary.svelte";
   import CallTree from "./CallTree.svelte";
@@ -29,9 +28,6 @@
   import FunctionsPage from "./FunctionsPage.svelte";
 
   provideVSCodeDesignSystem().register(
-    vsCodePanels(),
-    vsCodePanelTab(),
-    vsCodePanelView(),
     vsCodeProgressRing(),
     vsCodeButton(),
   );
@@ -298,14 +294,14 @@
 </script>
 
 <main>
-  <vscode-panels>
-    <vscode-panel-tab id="summary-tab">Summary</vscode-panel-tab>
-    <vscode-panel-tab id="call-tree-tab">Call Tree</vscode-panel-tab>
-    <vscode-panel-tab id="caller-callee-tab">Caller/Callee</vscode-panel-tab>
-    <vscode-panel-tab id="functions-tab">Functions</vscode-panel-tab>
+  <vscode-tabs panel>
+    <vscode-tab-header slot="header" id="summary-tab">Summary</vscode-tab-header>
+    <vscode-tab-header slot="header" id="call-tree-tab">Call Tree</vscode-tab-header>
+    <vscode-tab-header slot="header" id="caller-callee-tab">Caller/Callee</vscode-tab-header>
+    <vscode-tab-header slot="header" id="functions-tab">Functions</vscode-tab-header>
 
-    <vscode-panel-view id="summary-view">
-      <section>
+    <vscode-tab-panel id="summary-view">
+      <vscode-scrollable>
         <Summary
           navigate={(functionId) => changeActiveFunction(functionId)}
           filter={(timeSpan, excludedProcesses, excludedThreads) =>
@@ -325,11 +321,11 @@
           {activeFunction}
           {activeSelectionFilter}
         />
-      </section>
-    </vscode-panel-view>
+      </vscode-scrollable>
+    </vscode-tab-panel>
 
-    <vscode-panel-view id="call-tree-view">
-      <section>
+    <vscode-tab-panel id="call-tree-view">
+      <vscode-scrollable>
         <CallTree
           navigate={(functionId) => changeActiveFunction(functionId)}
           roots={callTreeRoots}
@@ -337,10 +333,10 @@
           {sampleSources}
           {activeFunction}
         />
-      </section>
-    </vscode-panel-view>
+      </vscode-scrollable>
+    </vscode-tab-panel>
 
-    <vscode-panel-view id="caller-callee-view">
+    <vscode-tab-panel id="caller-callee-view" class="full-panel">
       <section>
         <CallerCallee
           navigate={(functionId) => changeActiveFunction(functionId)}
@@ -348,47 +344,53 @@
           activeSourceIndex={activeMainSourceIndex}
         />
       </section>
-    </vscode-panel-view>
+    </vscode-tab-panel>
 
-    <vscode-panel-view id="functions-view">
-      <section>
+    <vscode-tab-panel id="functions-view">
+      <vscode-scrollable>
         <FunctionsPage
           navigate={(functionId) => changeActiveFunction(functionId)}
           {sampleSources}
           {processes}
           {activeFunction}
         />
-      </section>
-    </vscode-panel-view>
+      </vscode-scrollable>
+    </vscode-tab-panel>
 
-    <!-- <vscode-panel-view id="flame-graph-view">
+    <!-- <vscode-tab-panel id="flame-graph-view">
       flame graph.
-    </vscode-panel-view> -->
-  </vscode-panels>
+    </vscode-tab-panel> -->
+  </vscode-tabs>
 </main>
 
 <style>
   main {
     height: 100%;
-    padding: 0 8px;
   }
-  vscode-panels {
+  vscode-tabs {
     height: 100%;
+    --vscode-panel-background: var(--background);
+    display: flex;
+    flex-direction: column;
   }
-  vscode-panel-tab {
+  /* :global(vscode-tabs > .header.panel) {
+    background-color: var(--background);
+  } */
+  vscode-tab-header {
     text-transform: uppercase;
   }
-  /* :global(vscode-panels) :global(.tablist) {
+  vscode-tab-panel {
     background-color: var(--background);
-    position: sticky;
-    top: 0;
-  } */
-  vscode-panel-view {
-    height: 100%;
-    padding-left: calc(var(--design-unit) * 1px);
-    padding-right: calc(var(--design-unit) * 1px);
+    flex: 1;
+    overflow: auto;
+    padding: 0 8px;
   }
-  vscode-panel-view > section {
+  vscode-scrollable {
+    height: 100%;
+  }
+
+  section {
+    height: 100%;
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/webview-ui/src/App.svelte
+++ b/webview-ui/src/App.svelte
@@ -17,7 +17,6 @@
   import {
     provideVSCodeDesignSystem,
     vsCodeProgressRing,
-    vsCodeButton,
   } from "@vscode/webview-ui-toolkit";
 
   import "@vscode-elements/elements";
@@ -29,7 +28,6 @@
 
   provideVSCodeDesignSystem().register(
     vsCodeProgressRing(),
-    vsCodeButton(),
   );
 
   let totalTime: TimeSpan | null = $state(null);

--- a/webview-ui/src/Summary.svelte
+++ b/webview-ui/src/Summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { run, stopPropagation } from "svelte/legacy";
-
   import Pane from "./components/Pane.svelte";
   import FunctionTable from "./components/FunctionTable.svelte";
   import FunctionTableRow from "./components/FunctionTableRow.svelte";
   import TimeLine from "./components/TimeLine.svelte";
   import InfoTable from "./components/InfoTable.svelte";
+  import ActionIcon from "./components/ActionIcon.svelte";
   import type {
     FunctionId,
     ProcessFunction,
@@ -149,72 +148,55 @@
 
     {#snippet toolbar()}
       <div class="toolbar-buttons">
-        <vscode-button
-          role="button"
-          tabindex="0"
-          appearance="icon"
-          aria-label="Apply Filter"
-          title="Apply Filter"
-          disabled={!hasFilterChanges}
-          onclick={stopPropagation(applyFiler)}
-          onkeypress={stopPropagation(applyFiler)}
-        >
-          <span class="codicon codicon-filter"></span>
-        </vscode-button>
-        <vscode-button
-          role="button"
-          tabindex="0"
-          appearance="icon"
-          aria-label="Reset Selection Filter"
-          title="Reset Selection Filter"
+        <div class="toolbar-button">
+          <ActionIcon
+            disabled={!hasFilterChanges}
+            label="Apply Filter"
+            onclick={(e) => { e.stopPropagation(); applyFiler(); }}
+            >
+            <span class="codicon codicon-filter"></span>
+          </ActionIcon>
+        </div>
+        <div class="toolbar-button">
+        <ActionIcon
+          label="Reset Selection Filter"
           disabled={!hasSelectionFilter}
-          onclick={stopPropagation(clearSelectionFilter)}
-          onkeypress={stopPropagation(clearSelectionFilter)}
+          onclick={(e) => { e.stopPropagation(); clearSelectionFilter(); }}
         >
           <!-- <span class="codicon codicon-refresh"></span> -->
           <span class="icon-group">
             <span class="codicon codicon-filter"></span>
             <span class="icon-corner codicon codicon-error"></span>
           </span>
-        </vscode-button>
-
-        <vscode-button
-          role="button"
-          tabindex="0"
-          appearance="icon"
-          aria-label="Clear Selection"
-          title="Clear Selection"
+        </ActionIcon>
+      </div>
+      <div class="toolbar-button">
+        <ActionIcon
+          label="Clear Selection"
           disabled={!hasSelection}
-          onclick={stopPropagation(clearSelection)}
-          onkeypress={stopPropagation(clearSelection)}
+          onclick={(e) => { e.stopPropagation(); clearSelection(); }}
         >
           <span class="codicon codicon-clear-all"></span>
-        </vscode-button>
-
-        <vscode-button
-          role="button"
-          tabindex="0"
-          appearance="icon"
-          aria-label="Zoom to Selection"
-          title="Zoom to Selection"
+        </ActionIcon>
+      </div>
+      <div class="toolbar-button">
+        <ActionIcon
+          label="Zoom to Selection"
           disabled={!hasSelection}
-          onclick={stopPropagation(zoomToSelection)}
-          onkeypress={stopPropagation(zoomToSelection)}
+          onclick={(e) => { e.stopPropagation(); zoomToSelection(); }}
         >
           <span class="codicon codicon-zoom-in"></span>
-        </vscode-button>
-        <vscode-button
-          role="button"
-          tabindex="0"
-          appearance="icon"
-          aria-label="Reset Zoom"
-          title="Reset Zoom"
+        </ActionIcon>
+      </div>
+      <div class="toolbar-button">
+        <ActionIcon
+          label="Reset Zoom"
           disabled={!isZoomed}
-          onclick={stopPropagation(resetZoom)}
-          onkeypress={stopPropagation(resetZoom)}
+          onclick={(e) => { e.stopPropagation(); resetZoom(); }}
         >
           <span class="codicon codicon-zoom-out"></span>
-        </vscode-button>
+        </ActionIcon>
+      </div>
       </div>
     {/snippet}
   </Pane>
@@ -258,13 +240,19 @@
 <style>
   .toolbar-buttons {
     display: flex;
-    gap: 4px;
+    align-items: center;
+    justify-content: flex-end;
     margin-left: 2px;
     margin-right: 2px;
   }
 
+  .toolbar-button {
+    margin-right: 4px;
+  }
+
   .icon-group {
     position: relative;
+    height: 16px;
   }
 
   span.icon-corner {

--- a/webview-ui/src/components/ActionIcon.svelte
+++ b/webview-ui/src/components/ActionIcon.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+
+  interface Props {
+    children?: import('svelte').Snippet;
+    disabled: boolean
+    label: string
+    onclick?: (event : MouseEvent) => void;
+  }
+
+  let { children, disabled, label, onclick }: Props = $props();
+
+</script>
+
+<button
+  class="action-button"
+  aria-label={label}
+  disabled={disabled}
+  onclick={(event) => onclick?.(event)}
+>
+  {@render children?.()}
+</button>
+
+<style>
+    .action-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    .action-button {
+      display: flex;
+      align-items: center;
+      border-color: transparent;
+      border-style: solid;
+      border-width: 1px;
+      border-radius: 5px;
+      color: var(--vscode-icon-foreground);
+      background-color: transparent;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    .action-button:hover {
+      background-color: var(--vscode-toolbar-hoverBackground);
+    }
+
+    .action-button:active {
+      background-color: var(--vscode-toolbar-activeBackground);
+    }
+
+    .action-button:focus {
+      outline: none;
+    }
+
+    .action-button:focus-visible {
+      border-color: var(--vscode-focusBorder);
+    }
+</style>

--- a/webview-ui/src/components/Checkbox.svelte
+++ b/webview-ui/src/components/Checkbox.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  interface Props {
+    disabled?: boolean;
+    checked: boolean;
+    onchange?: (event : Event) => void;
+  }
+
+  let { disabled, checked = $bindable(), onchange }: Props = $props();
+</script>
+
+
+<input
+  class="checkbox-control codicon checkbox-icon"
+  class:codicon-check={checked}
+  type="checkbox"
+  bind:checked={checked}
+  {disabled}
+  onchange={(event) => {onchange?.(event)}}
+/>
+
+<style>
+  .checkbox-control {
+    position: relative;
+    width: calc(var(--design-unit) * 4px);
+    height: calc(var(--design-unit) * 4px);
+    box-sizing: border-box;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-settings-checkboxBorder);
+    background: var(--vscode-settings-checkboxBackground);
+    outline: none;
+    cursor: pointer;
+    appearance: none;
+    margin: 0 calc(var(--design-unit) * 1.5px) 0 0;
+  }
+
+  input.checkbox-icon {
+    font-size: 11pt;
+  }
+
+  .checkbox-control:active {
+    background: var(--vscode-settings-checkboxBackground);
+    border-color: var(--vscode-focusBorder);
+  }
+  .checkbox-control:focus-visible {
+    border: 1px solid var(--vscode-focusBorder);
+  }
+</style>

--- a/webview-ui/src/components/FunctionTableTreeNode.svelte
+++ b/webview-ui/src/components/FunctionTableTreeNode.svelte
@@ -9,7 +9,6 @@
   } from "../utilities/types";
 
   import FunctionTableRow from "./FunctionTableRow.svelte";
-  import exp from "constants";
 
   interface Props {
     processKey: number;

--- a/webview-ui/src/components/TimeLine.svelte
+++ b/webview-ui/src/components/TimeLine.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TimeSpan, ProcessInfo } from "../utilities/types";
+  import Checkbox from "./Checkbox.svelte";
 
   interface Props {
     displayTime: TimeSpan | null;
@@ -287,13 +288,10 @@
                 aria-expanded={expanded[processIndex]}
               ></div>
               <div class="input-group">
-                <input
-                  type="checkbox"
-                  class="checkbox-control codicon"
-                  class:codicon-check={checked[processIndex].process}
+                <Checkbox
                   bind:checked={checked[processIndex].process}
                   onchange={() => toggleProcessFilter(processIndex)}
-                />
+                ></Checkbox>
                 {process.name} (PID: {process.osId})
               </div>
             </div>
@@ -401,17 +399,11 @@
                     class="twistie codicon codicon-chevron-down"
                   ></div>
                   <div class="input-group">
-                    <input
-                      class="checkbox-control codicon"
-                      class:codicon-check={checked[processIndex].threads[
-                        threadIndex
-                      ]}
-                      type="checkbox"
+                    <Checkbox
                       bind:checked={checked[processIndex].threads[threadIndex]}
-                      disabled={!checked[processIndex].process}
                       onchange={() =>
                         toggleThreadFilter(processIndex, threadIndex)}
-                    />
+                    ></Checkbox>
                     {thread.name === null ? "[thread]" : thread.name} (TID: {thread.osId})
                   </div>
                 </div>
@@ -555,29 +547,6 @@
   .input-group {
     display: flex;
     align-items: center;
-  }
-
-  .checkbox-control {
-    position: relative;
-    width: calc(var(--design-unit) * 4px);
-    height: calc(var(--design-unit) * 4px);
-    box-sizing: border-box;
-    border-radius: calc(var(--checkbox-corner-radius) * 1px);
-    border: calc(var(--border-width) * 1px) solid var(--checkbox-border);
-    background: var(--checkbox-background);
-    outline: none;
-    cursor: pointer;
-    appearance: none;
-    margin: 0 calc(var(--design-unit) * 1.5px) 0 0;
-    font-size: 11pt;
-  }
-
-  .checkbox-control:active {
-    background: var(--checkbox-background);
-    border-color: var(--focus-border);
-  }
-  .checkbox-control:focus-visible {
-    border: calc(var(--border-width) * 1px) solid var(--focus-border);
   }
 
   .time-data {


### PR DESCRIPTION
The official VSCode webview UI toolkit has been deprecated.
We replace it by self-build custom components and `vscode-elements/elements`.